### PR TITLE
Enforce access token type in auth dependencies

### DIFF
--- a/api/app/deps.py
+++ b/api/app/deps.py
@@ -32,7 +32,10 @@ async def get_current_user(
             settings.JWT_SECRET,
             algorithms=[settings.JWT_ALGORITHM]
         )
-        
+        token_type = payload.get("type")
+        if token_type != "access":
+            raise UnauthorizedError("Invalid token type")
+
         user_id_str = payload.get("sub")  # ✅ String olarak al
         if user_id_str is None:
             raise UnauthorizedError("Invalid token")

--- a/api/tests/test_auth_tokens.py
+++ b/api/tests/test_auth_tokens.py
@@ -1,0 +1,38 @@
+import pytest
+from jose import jwt
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.routes.auth import create_access_token, create_refresh_token
+from app.deps import get_current_user
+from app.config import settings
+from app.core.exceptions import UnauthorizedError
+
+
+@pytest.mark.asyncio
+async def test_token_type_claims():
+    access = create_access_token({"sub": "1"})
+    refresh = create_refresh_token({"sub": "1"})
+
+    payload_access = jwt.decode(access, settings.JWT_SECRET, algorithms=[settings.JWT_ALGORITHM])
+    payload_refresh = jwt.decode(refresh, settings.JWT_SECRET, algorithms=[settings.JWT_ALGORITHM])
+
+    assert payload_access.get("type") == "access"
+    assert payload_refresh.get("type") == "refresh"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_refresh_token(test_db, test_user):
+    token = create_refresh_token({"sub": str(test_user.id)})
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(UnauthorizedError):
+        await get_current_user(test_db, creds)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_accepts_access_token(test_db, test_user):
+    token = create_access_token({"sub": str(test_user.id)})
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    user = await get_current_user(test_db, creds)
+    assert user.id == test_user.id


### PR DESCRIPTION
## Summary
- validate access token `type` claim inside `get_current_user`
- add tests for token type and refresh token rejection
- guard test client fixture when httpx is missing

## Testing
- `SECRET_KEY=secret DATABASE_URL=sqlite+aiosqlite:///:memory: JWT_SECRET=testsecret GOOGLE_CLIENT_ID=client GOOGLE_CLIENT_SECRET=secret pytest -q` *(fails: No module named 'sqlalchemy')*
- `pip install httpx==0.25.2` *(fails: Could not connect to proxy)*
- `pip install sqlalchemy==2.0.23` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6898f3f58448832aa0757a43b8a3eaf6