### PR TITLE
Add API endpoint tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_register_success(client):
+    payload = {"email": "newuser@example.com", "password": "strongpass123"}
+    response = await client.post("/auth/register", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == payload["email"]
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_email(client, test_user):
+    payload = {"email": test_user.email, "password": "password123"}
+    response = await client.post("/auth/register", json=payload)
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_login_success(client):
+    payload = {"email": "loginuser@example.com", "password": "password123"}
+    await client.post("/auth/register", json=payload)
+    response = await client.post("/auth/login", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+
+
+@pytest.mark.asyncio
+async def test_login_wrong_password(client):
+    payload = {"email": "wrongpass@example.com", "password": "correctpass"}
+    await client.post("/auth/register", json=payload)
+    response = await client.post(
+        "/auth/login", json={"email": payload["email"], "password": "badpass"}
+    )
+    assert response.status_code == 401
+

--- a/api/tests/test_projects.py
+++ b/api/tests/test_projects.py
@@ -1,0 +1,50 @@
+import pytest
+from app.models import Project, ProjectBudgetType, ProjectStatus
+
+
+@pytest.mark.asyncio
+async def test_list_projects_empty(client):
+    response = await client.get("/projects")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_project_not_found(client):
+    response = await client.get("/projects/999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_project_success(client, test_db, test_customer):
+    project = Project(
+        title="Test Project Title",
+        description="This is a test project description that is definitely long enough to meet validation requirements.",
+        customer_id=test_customer.id,
+        budget_type=ProjectBudgetType.fixed,
+        status=ProjectStatus.open,
+        currency="USD",
+    )
+    test_db.add(project)
+    await test_db.commit()
+    await test_db.refresh(project)
+
+    response = await client.get(f"/projects/{project.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == project.id
+    assert data["title"] == project.title
+
+
+@pytest.mark.asyncio
+async def test_create_project_requires_auth(client):
+    payload = {
+        "title": "Unauthorized Project",
+        "description": "This project should not be created due to missing auth and serves as a negative test case for authorization.",
+        "budget_type": "fixed",
+        "currency": "USD",
+    }
+    response = await client.post("/projects", json=payload)
+    assert response.status_code == 401
+


### PR DESCRIPTION
## Summary
- add auth API tests for registration and login flows
- add project API tests for listing and fetching projects
- run tests in GitHub Actions using pytest

## Testing
- `pytest api/tests/test_auth.py api/tests/test_projects.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6898f83af3ec832aad1889b8530677b5