### PR TITLE
chore: remove unused secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,6 @@ AWS_S3_REGION=us-east-1
 APP_NAME=Gigerly.io Platform
 APP_VERSION=1.0.0
 API_V1_STR=/api/v1
-SECRET_KEY=your-secret-key-for-app
 DEBUG=true
 ENVIRONMENT=development
 CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -16,7 +16,6 @@ class Settings(BaseSettings):
     APP_NAME: str = "Gigerly.io Platform"
     APP_VERSION: str = "1.0.0"
     API_V1_STR: str = "/api/v1"
-    SECRET_KEY: str
     DEBUG: bool = False
     ENVIRONMENT: str = "development"
     ALLOWED_HOSTS: List[str] = ["localhost", "127.0.0.1"]


### PR DESCRIPTION
## Summary
- drop unused `SECRET_KEY` and rely on `JWT_SECRET`
- clean up env example to match settings

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r api/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*

------
https://chatgpt.com/codex/tasks/task_e_6898fd1883e4832a876ef37c5fd32078