### PR TITLE
feat(web): convert Dockerfile to multi-stage build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,25 +1,39 @@
-# web/Dockerfile (Çok basit versiyon)
-FROM node:18-alpine
+# web/Dockerfile (multi-stage)
+
+# Builder stage
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json ./
+# Install dependencies and build the application
+COPY package.json package-lock.json ./
+RUN npm ci
 
-# Install dependencies
-RUN npm install
-
-# Copy source code
 COPY . .
-
-# Set environment
 ENV NEXT_TELEMETRY_DISABLED 1
-
-# Build the application
 RUN npm run build
 
-# Expose port
+# Runtime stage
+FROM node:18-alpine AS runtime
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# Install only production dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Copy build output
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.js ./next.config.js
+
+# Run as non-root user
+RUN chown -R node:node /app
+USER node
+
 EXPOSE 3000
 
-# Start the application
 CMD ["npm", "start"]
+


### PR DESCRIPTION
## Summary
- split web Dockerfile into builder and runtime stages
- install dependencies with npm ci and produce build output
- copy only build artifacts and run as non-root in runtime image

## Testing
- `docker build web -t webtest` (fails: command not found)
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_6899003ca094832aaae765a217e22537