### PR TITLE
Batch project view counters via Redis

### DIFF
--- a/api/app/worker.py
+++ b/api/app/worker.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import time
 from typing import Any, Dict
 
 from app.config import settings
@@ -10,15 +11,18 @@ from app.core.database import AsyncSessionLocal
 from app.core.redis import redis_manager
 from app.services.fcm import send_push_notification
 from app.services.email import send_email
-from app.models import Notification
+from app.models import Notification, Project
+from sqlalchemy import update, case
 
 logger = logging.getLogger(__name__)
 
 class BackgroundWorker:
     """Background job processor"""
-    
+
     def __init__(self):
         self.running = False
+        self.view_flush_interval = 60  # seconds
+        self._last_view_flush = 0.0
     
     async def start(self):
         """Start the worker"""
@@ -53,7 +57,12 @@ class BackgroundWorker:
         
         # Process email queue
         await self.process_emails()
-        
+
+        # Flush project view counts periodically
+        if time.monotonic() - self._last_view_flush >= self.view_flush_interval:
+            await self.flush_project_view_counts()
+            self._last_view_flush = time.monotonic()
+
         # Add other job types here as needed
     
     async def process_notifications(self):
@@ -99,9 +108,44 @@ class BackgroundWorker:
                 )
                 
                 logger.info(f"Email sent to {job_data['to_email']}")
-                
+
             except Exception as e:
                 logger.error(f"Failed to process email: {e}")
+
+    async def flush_project_view_counts(self):
+        """Flush project view counters from Redis to the database"""
+        keys = await redis_manager.redis.keys("project:*:views")
+        if not keys:
+            return
+
+        values = await redis_manager.redis.mget(keys)
+        increments: Dict[int, int] = {}
+        for key, value in zip(keys, values):
+            if value is None:
+                continue
+            try:
+                project_id = int(key.split(":")[1])
+                increments[project_id] = increments.get(project_id, 0) + int(value)
+            except (ValueError, IndexError):
+                logger.warning(f"Invalid project view key: {key}")
+
+        if not increments:
+            return
+
+        async with AsyncSessionLocal() as session:
+            ids = list(increments.keys())
+            case_stmt = case(increments, value=Project.id, else_=0)
+            stmt = (
+                update(Project)
+                .where(Project.id.in_(ids))
+                .values(view_count=Project.view_count + case_stmt)
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+        # Clear Redis keys after flushing
+        await redis_manager.delete(*keys)
+        logger.info(f"Flushed {len(increments)} project view counts to database")
 
 # Worker instance
 worker = BackgroundWorker()


### PR DESCRIPTION
## Summary
- Move project view increments to Redis counters
- Add background worker task to batch project view counts into DB

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689904b728fc832ab9bfafe65c443f5d