### PR TITLE
Use blocking Redis pops for background worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Modern, scalable gigerly.io marketplace built with **FastAPI** and **Next.js**.
                         └─────────────────┘
 ```
 
+## ⚙️ Background Worker Queues
+
+The background worker blocks on Redis lists to wait for jobs:
+
+- `notification_queue` – push notification payloads
+- `email_queue` – email payloads
+
+`BLPOP` uses a timeout of `0`, so the worker remains blocked until a job appears on either queue.
+
 ### Tech Stack
 
 **Backend:**

--- a/api/app/worker.py
+++ b/api/app/worker.py
@@ -3,108 +3,114 @@
 
 import asyncio
 import logging
-from typing import Any, Dict
 
-from app.config import settings
-from app.core.database import AsyncSessionLocal
 from app.core.redis import redis_manager
-from app.services.fcm import send_push_notification
 from app.services.email import send_email
-from app.models import Notification
+from app.services.fcm import send_push_notification
 
 logger = logging.getLogger(__name__)
 
+
 class BackgroundWorker:
     """Background job processor"""
-    
+
     def __init__(self):
         self.running = False
-    
+        self.NOTIFICATION_QUEUE = "notification_queue"
+        self.EMAIL_QUEUE = "email_queue"
+        # 0 timeout blocks until a job is available
+        self.QUEUE_TIMEOUT = 0
+
     async def start(self):
         """Start the worker"""
         logger.info("🔄 Starting background worker...")
-        
+
         self.running = True
-        
+
         # Connect to Redis
         await redis_manager.connect()
-        
+
         # Start processing jobs
         while self.running:
             try:
                 await self.process_jobs()
-                await asyncio.sleep(5)  # Check for jobs every 5 seconds
-                
+
             except Exception as e:
                 logger.error(f"Worker error: {e}", exc_info=True)
                 await asyncio.sleep(10)  # Wait longer on error
-    
+
     async def stop(self):
         """Stop the worker"""
         logger.info("🛑 Stopping background worker...")
         self.running = False
         await redis_manager.disconnect()
-    
+
     async def process_jobs(self):
-        """Process pending background jobs"""
-        
-        # Process notification queue
-        await self.process_notifications()
-        
-        # Process email queue
-        await self.process_emails()
-        
+        """Wait for and dispatch background jobs"""
+
+        job = await redis_manager.redis.blpop(
+            self.NOTIFICATION_QUEUE,
+            self.EMAIL_QUEUE,
+            timeout=self.QUEUE_TIMEOUT,
+        )
+
+        if not job:
+            return
+
+        queue_name, payload = job
+        if queue_name == self.NOTIFICATION_QUEUE:
+            await self.process_notifications(payload)
+        elif queue_name == self.EMAIL_QUEUE:
+            await self.process_emails(payload)
+
         # Add other job types here as needed
-    
-    async def process_notifications(self):
-        """Process pending push notifications"""
-        
-        # Get pending notifications from Redis queue
-        notification_job = await redis_manager.redis.lpop("notification_queue")
-        
-        if notification_job:
-            try:
-                import json
-                job_data = json.loads(notification_job)
-                
-                # Send push notification
-                await send_push_notification(
-                    user_id=job_data["user_id"],
-                    title=job_data["title"],
-                    message=job_data["message"],
-                    data=job_data.get("data", {})
-                )
-                
-                logger.info(f"Push notification sent to user {job_data['user_id']}")
-                
-            except Exception as e:
-                logger.error(f"Failed to process notification: {e}")
-    
-    async def process_emails(self):
-        """Process pending emails"""
-        
-        email_job = await redis_manager.redis.lpop("email_queue")
-        
-        if email_job:
-            try:
-                import json
-                job_data = json.loads(email_job)
-                
-                # Send email
-                await send_email(
-                    to_email=job_data["to_email"],
-                    subject=job_data["subject"],
-                    content=job_data["content"],
-                    template=job_data.get("template")
-                )
-                
-                logger.info(f"Email sent to {job_data['to_email']}")
-                
-            except Exception as e:
-                logger.error(f"Failed to process email: {e}")
+
+    async def process_notifications(self, notification_job: str):
+        """Process a push notification payload"""
+
+        try:
+            import json
+
+            job_data = json.loads(notification_job)
+
+            # Send push notification
+            await send_push_notification(
+                user_id=job_data["user_id"],
+                title=job_data["title"],
+                message=job_data["message"],
+                data=job_data.get("data", {}),
+            )
+
+            logger.info(f"Push notification sent to user {job_data['user_id']}")
+
+        except Exception as e:
+            logger.error(f"Failed to process notification: {e}")
+
+    async def process_emails(self, email_job: str):
+        """Process an email payload"""
+
+        try:
+            import json
+
+            job_data = json.loads(email_job)
+
+            # Send email
+            await send_email(
+                to_email=job_data["to_email"],
+                subject=job_data["subject"],
+                content=job_data["content"],
+                template=job_data.get("template"),
+            )
+
+            logger.info(f"Email sent to {job_data['to_email']}")
+
+        except Exception as e:
+            logger.error(f"Failed to process email: {e}")
+
 
 # Worker instance
 worker = BackgroundWorker()
+
 
 async def main():
     """Main worker function"""
@@ -114,6 +120,7 @@ async def main():
         logger.info("Worker interrupted by user")
     finally:
         await worker.stop()
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- replace polling loop with blocking BLPOP dispatch
- pass popped payloads to notification and email handlers directly
- document Redis queue names and blocking timeout

## Testing
- `pip install -r api/requirements.txt` *(failed: Could not find a version that satisfies the requirement fastapi==0.104.1)*
- `pytest` *(failed: No module named 'sqlalchemy')*
- `black --check api/app/worker.py`
- `isort --check-only api/app/worker.py`

------
https://chatgpt.com/codex/tasks/task_e_6899117fab80832a9b8293602608628d