### PR TITLE
Use offline Google token verification

### DIFF
--- a/api/app/routes/auth.py
+++ b/api/app/routes/auth.py
@@ -9,7 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from jose import JWTError, jwt
 from passlib.context import CryptContext
-import httpx
+import requests
+from cachecontrol import CacheControl
+from cachecontrol.caches import DictCache
+from cachecontrol.heuristics import ExpiresAfter
+from google.oauth2 import id_token
+from google.auth.transport import requests as google_requests
 
 from app.core.database import get_db
 from app.core.redis import get_redis, RedisManager
@@ -27,6 +32,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth")
+
+# Cached session for verifying Google ID tokens to reduce repeated JWKS downloads
+_cached_session = CacheControl(
+    requests.Session(), cache=DictCache(), heuristic=ExpiresAfter(seconds=300)
+)
+google_request = google_requests.Request(session=_cached_session)
 
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -76,17 +87,24 @@ async def authenticate_user(db: AsyncSession, email: str, password: str) -> User
     return user
 
 
-async def get_or_create_google_user(db: AsyncSession, id_token: str) -> User:
+async def get_or_create_google_user(db: AsyncSession, token: str) -> User:
     """Verify Google token and return existing or newly created user"""
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                f"https://www.googleapis.com/oauth2/v1/userinfo?access_token={id_token}"
-            )
-            response.raise_for_status()
-        except httpx.HTTPError:
-            raise UnauthorizedError("Invalid Google token")
-        google_user = response.json()
+    try:
+        id_info = id_token.verify_oauth2_token(
+            token, google_request, audience=settings.GOOGLE_CLIENT_ID
+        )
+    except ValueError:
+        raise UnauthorizedError("Invalid Google token")
+
+    google_user = {
+        "id": id_info.get("sub"),
+        "email": id_info.get("email"),
+        "verified_email": id_info.get("email_verified", False),
+        "name": id_info.get("name"),
+        "given_name": id_info.get("given_name"),
+        "family_name": id_info.get("family_name"),
+        "picture": id_info.get("picture"),
+    }
 
     if not google_user.get("email"):
         raise UnauthorizedError("Email not provided by Google")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -21,6 +21,8 @@ bcrypt==3.2.2
 python-multipart==0.0.6
 authlib==1.2.1
 httpx==0.25.2
+google-auth==2.27.0
+cachecontrol==0.13.1
 
 # Pydantic & Validation
 pydantic==2.5.0

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -36,3 +36,17 @@ async def test_login_wrong_password(client):
         "/auth/login", json={"email": payload["email"], "password": "badpass"}
     )
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_google_invalid_token_no_network(mocker, test_db):
+    from app.routes import auth as auth_module
+
+    mocker.patch.object(
+        auth_module.google_request,
+        "__call__",
+        side_effect=AssertionError("network call"),
+    )
+
+    with pytest.raises(auth_module.UnauthorizedError):
+        await auth_module.get_or_create_google_user(test_db, "invalid-token")


### PR DESCRIPTION
## Summary
- verify Google ID tokens offline using `google.oauth2.id_token`
- cache Google JWKS to avoid repeated downloads
- test that invalid Google tokens are rejected without making network calls

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689914ec0cd0832ab0bcacf4de6eae7e