### PR TITLE
Add configurable database pool settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # .env.example
 # Database
 DATABASE_URL=postgresql://gigerlyio_user:gigerlyio_pass@localhost:5432/gigerlyio_db
+POOL_SIZE=20
+MAX_OVERFLOW=0
 
 # Redis
 REDIS_URL=redis://localhost:6379/0

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     
     # Database
     DATABASE_URL: str
+    POOL_SIZE: int = 20
+    MAX_OVERFLOW: int = 0
     
     # Redis
     REDIS_URL: str = "redis://localhost:6379/0"

--- a/api/app/core/database.py
+++ b/api/app/core/database.py
@@ -15,8 +15,8 @@ engine = create_async_engine(
     future=True,
     pool_pre_ping=True,
     pool_recycle=3600,
-    pool_size=20,
-    max_overflow=0,
+    pool_size=settings.POOL_SIZE,
+    max_overflow=settings.MAX_OVERFLOW,
 )
 
 # Async session factory
@@ -32,6 +32,8 @@ sync_engine = create_engine(
     echo=settings.DEBUG,
     pool_pre_ping=True,
     pool_recycle=3600,
+    pool_size=settings.POOL_SIZE,
+    max_overflow=settings.MAX_OVERFLOW,
 )
 
 SessionLocal = sessionmaker(
@@ -89,4 +91,5 @@ async def check_db_health() -> bool:
     except Exception as e:
         logger.error(f"Database health check failed: {e}")
         return False
+
 get_session = get_db


### PR DESCRIPTION
## Summary
- read database pool configuration from environment
- expose POOL_SIZE and MAX_OVERFLOW in Settings
- document new database pool variables in .env.example

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1 (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_6899196c4a00832ab69988e786068ec4