### PR TITLE
feat: add auth context provider

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { AuthProvider } from '@/hooks/use-auth'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -17,7 +18,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   )
 }

--- a/web/hooks/use-auth.ts
+++ b/web/hooks/use-auth.ts
@@ -1,58 +1,75 @@
 // web/hooks/use-auth.ts
 'use client'
 
-import { useState, useEffect } from 'react'
+import { createContext, useContext, useState, useEffect } from 'react'
 import { User } from '@/types'
 
-export function useAuth() {
+interface AuthContextValue {
+  user: User | null
+  isLoading: boolean
+  login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>
+  logout: () => void
+  isAuthenticated: boolean
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+let userPromise: Promise<User | null> | null = null
+
+async function fetchUserInfo(token: string): Promise<User | null> {
+  if (!userPromise) {
+    userPromise = fetch('/api/v1/auth/me', {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    })
+      .then(async (response) => {
+        if (response.ok) {
+          return response.json()
+        }
+        localStorage.removeItem('access_token')
+        return null
+      })
+      .catch((error) => {
+        console.error('Failed to fetch user info:', error)
+        localStorage.removeItem('access_token')
+        return null
+      })
+  }
+  return userPromise
+}
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    // Check for stored auth token and validate
     const token = localStorage.getItem('access_token')
     if (token) {
-      // Validate token and get user info
-      fetchUserInfo(token)
+      fetchUserInfo(token).then((userData) => {
+        if (userData) {
+          setUser(userData)
+        }
+        setIsLoading(false)
+      })
     } else {
       setIsLoading(false)
     }
   }, [])
 
-  const fetchUserInfo = async (token: string) => {
-    try {
-      const response = await fetch('/api/v1/auth/me', {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      })
-      
-      if (response.ok) {
-        const userData = await response.json()
-        setUser(userData)
-      } else {
-        localStorage.removeItem('access_token')
-      }
-    } catch (error) {
-      console.error('Failed to fetch user info:', error)
-      localStorage.removeItem('access_token')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
   const login = async (email: string, password: string) => {
     const response = await fetch('/api/v1/auth/login', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ email, password })
+      body: JSON.stringify({ email, password }),
     })
 
     if (response.ok) {
       const data = await response.json()
       localStorage.setItem('access_token', data.access_token)
+      userPromise = Promise.resolve(data.user)
       setUser(data.user)
       return { success: true }
     } else {
@@ -63,14 +80,25 @@ export function useAuth() {
 
   const logout = () => {
     localStorage.removeItem('access_token')
+    userPromise = null
     setUser(null)
   }
 
-  return {
+  const value: AuthContextValue = {
     user,
     isLoading,
     login,
     logout,
-    isAuthenticated: !!user
+    isAuthenticated: !!user,
   }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
 }

--- a/web/hooks/use-auth.tsx
+++ b/web/hooks/use-auth.tsx
@@ -1,4 +1,4 @@
-// web/hooks/use-auth.ts
+// web/hooks/use-auth.tsx
 'use client'
 
 import { createContext, useContext, useState, useEffect } from 'react'


### PR DESCRIPTION
## Summary
- add `AuthProvider` with memoized `/auth/me` request to share auth state
- wrap root layout with `AuthProvider`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899b163b424832aa3f529a6eaaf6586