### PR TITLE
Enable HTTP/2 on Nginx server

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -19,7 +19,7 @@ map $request_uri $rate_limit_key {
 
 # Main server block
 server {
-    listen 80;
+    listen 80 http2;
     server_name localhost;
 
     # Security headers


### PR DESCRIPTION
## Summary
- enable HTTP/2 by updating Nginx server block to `listen 80 http2;`

## Testing
- `nginx -t -c $(pwd)/nginx/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b1697900832a9683986463e333e1